### PR TITLE
ci: Disable conventional commits lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,3 @@ jobs:
         dotnet-version: 6.0.x
     - name: Lint solution
       run: dotnet format --no-restore --verify-no-changes
-  commitlint:
-    runs-on: ubuntu-latest
-    name: Conventional Commits
-    steps:
-      - name: Run commitlint
-        if: (github.actor!= 'dependabot[bot]') && (contains(github.head_ref, 'dependabot/') == false)
-        uses: opensource-nepal/commitlint@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,5 @@ jobs:
     name: Conventional Commits
     steps:
       - name: Run commitlint
+        if: (github.actor!= 'dependabot[bot]') && (contains(github.head_ref, 'dependabot/') == false)
         uses: opensource-nepal/commitlint@v1


### PR DESCRIPTION
The opensource-nepal/commitlint@v1 github action insists on limiting commit message length with no way of disabling it, resulting in faulty runs for dependabot.