### PR TITLE
fix: Increase timeouts for local LLMs

### DIFF
--- a/src/Cellm/AddIn/CellmConfiguration.cs
+++ b/src/Cellm/AddIn/CellmConfiguration.cs
@@ -12,6 +12,8 @@ public class CellmConfiguration
 
     public int MaxOutputTokens { get; init; }
 
+    public int HttpTimeoutInSeconds { get; init; }
+
     public int CacheTimeoutInSeconds { get; init; }
 }
 

--- a/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
+++ b/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
@@ -70,9 +70,9 @@ public class ResiliencePipelineConfigurator
     };
 
     private static bool IsCircuitBreakerError(HttpResponseMessage response) =>
-        response.StatusCode >= HttpStatusCode.InternalServerError ||
-        response.StatusCode == HttpStatusCode.ServiceUnavailable ||
-        response.StatusCode == HttpStatusCode.TooManyRequests;
+        response.StatusCode == HttpStatusCode.RequestTimeout ||
+        response.StatusCode == HttpStatusCode.TooManyRequests ||
+        response.StatusCode == HttpStatusCode.GatewayTimeout;
 
     private static bool IsCircuitBreakerException(Exception exception) =>
         IsRetryableException(exception) || IsCatastrophicException(exception);
@@ -88,9 +88,12 @@ public class ResiliencePipelineConfigurator
     };
 
     private static bool IsRetryableError(HttpResponseMessage response) =>
-        response.StatusCode >= HttpStatusCode.InternalServerError ||
         response.StatusCode == HttpStatusCode.RequestTimeout ||
-        response.StatusCode == HttpStatusCode.TooManyRequests;
+        response.StatusCode == HttpStatusCode.TooManyRequests ||
+        response.StatusCode == HttpStatusCode.BadGateway ||
+        response.StatusCode == HttpStatusCode.ServiceUnavailable ||
+        response.StatusCode == HttpStatusCode.GatewayTimeout;
+ 
 
     private static bool IsRetryableException(Exception exception) =>
         exception is HttpRequestException or TimeoutRejectedException;

--- a/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
+++ b/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Threading.RateLimiting;
+using Cellm.AddIn;
 using Polly;
 using Polly.CircuitBreaker;
 using Polly.Retry;
@@ -9,11 +10,13 @@ namespace Cellm.Services.Configuration;
 
 public class ResiliencePipelineConfigurator
 {
+    private readonly CellmConfiguration _cellmConfiguration;
     private readonly RateLimiterConfiguration _rateLimiterConfiguration;
     private readonly CircuitBreakerConfiguration _circuitBreakerConfiguration;
     private readonly RetryConfiguration _retryConfiguration;
 
     public ResiliencePipelineConfigurator(
+        CellmConfiguration cellmConfiguration,
         RateLimiterConfiguration rateLimiterConfiguration,
         CircuitBreakerConfiguration circuitBreakerConfiguration,
         RetryConfiguration retryConfiguration)
@@ -54,7 +57,7 @@ public class ResiliencePipelineConfigurator
                 MinimumThroughput = _circuitBreakerConfiguration.MinimumThroughput,
                 BreakDuration = TimeSpan.FromSeconds(_circuitBreakerConfiguration.BreakDurationInSeconds),
             })
-            .AddTimeout(TimeSpan.FromSeconds(_retryConfiguration.RequestTimeoutInSeconds))
+            .AddTimeout(TimeSpan.FromSeconds(_cellmConfiguration.HttpTimeoutInSeconds))
             .Build();
     }
 

--- a/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
+++ b/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
@@ -93,7 +93,7 @@ public class ResiliencePipelineConfigurator
         response.StatusCode == HttpStatusCode.BadGateway ||
         response.StatusCode == HttpStatusCode.ServiceUnavailable ||
         response.StatusCode == HttpStatusCode.GatewayTimeout;
- 
+
 
     private static bool IsRetryableException(Exception exception) =>
         exception is HttpRequestException or TimeoutRejectedException;

--- a/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
+++ b/src/Cellm/Services/Configuration/ResiliencePipelineConfigurator.cs
@@ -21,6 +21,7 @@ public class ResiliencePipelineConfigurator
         CircuitBreakerConfiguration circuitBreakerConfiguration,
         RetryConfiguration retryConfiguration)
     {
+        _cellmConfiguration = cellmConfiguration;
         _rateLimiterConfiguration = rateLimiterConfiguration;
         _circuitBreakerConfiguration = circuitBreakerConfiguration;
         _retryConfiguration = retryConfiguration;

--- a/src/Cellm/Services/Configuration/RetryConfiguration.cs
+++ b/src/Cellm/Services/Configuration/RetryConfiguration.cs
@@ -5,8 +5,4 @@ public class RetryConfiguration
     public int MaxRetryAttempts { get; init; }
 
     public int DelayInSeconds { get; init; }
-
-    public int RequestTimeoutInSeconds { get; init; }
-
-    public int TimeoutInSeconds { get; init; }
 }

--- a/src/Cellm/Services/ServiceLocator.cs
+++ b/src/Cellm/Services/ServiceLocator.cs
@@ -122,7 +122,7 @@ internal static class ServiceLocator
             anthropicHttpClient.BaseAddress = anthropicConfiguration.BaseAddress;
             anthropicHttpClient.DefaultRequestHeaders.Add("x-api-key", anthropicConfiguration.ApiKey);
             anthropicHttpClient.DefaultRequestHeaders.Add("anthropic-version", anthropicConfiguration.Version);
-            anthropicHttpClient.Timeout = TimeSpan.FromSeconds(cellmConfiguration.HttpTimeoutInSeconds + 1);
+            anthropicHttpClient.Timeout = TimeSpan.FromHours(1);
         }).AddResilienceHandler($"{nameof(AnthropicRequestHandler)}ResiliencePipeline", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
 
         var googleAiConfiguration = configuration.GetRequiredSection(nameof(GoogleAiConfiguration)).Get<GoogleAiConfiguration>()
@@ -131,7 +131,7 @@ internal static class ServiceLocator
         services.AddHttpClient<IRequestHandler<GoogleAiRequest, GoogleAiResponse>, GoogleAiRequestHandler>(googleHttpClient =>
         {
             googleHttpClient.BaseAddress = googleAiConfiguration.BaseAddress;
-            googleHttpClient.Timeout = TimeSpan.FromSeconds(cellmConfiguration.HttpTimeoutInSeconds + 1);
+            googleHttpClient.Timeout = TimeSpan.FromHours(1);
         }).AddResilienceHandler($"{nameof(GoogleAiRequestHandler)}ResiliencePipeline", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
 
         var openAiConfiguration = configuration.GetRequiredSection(nameof(OpenAiConfiguration)).Get<OpenAiConfiguration>()
@@ -141,7 +141,7 @@ internal static class ServiceLocator
         {
             openAiHttpClient.BaseAddress = openAiConfiguration.BaseAddress;
             openAiHttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {openAiConfiguration.ApiKey}");
-            openAiHttpClient.Timeout = TimeSpan.FromSeconds(cellmConfiguration.HttpTimeoutInSeconds + 1);
+            openAiHttpClient.Timeout = TimeSpan.FromHours(1);
         }).AddResilienceHandler($"{nameof(OpenAiRequestHandler)}ResiliencePipeline", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
 
         services

--- a/src/Cellm/Services/ServiceLocator.cs
+++ b/src/Cellm/Services/ServiceLocator.cs
@@ -112,7 +112,7 @@ internal static class ServiceLocator
             ?? throw new NullReferenceException(nameof(RetryConfiguration));
 
         var resiliencePipelineConfigurator = new ResiliencePipelineConfigurator(
-            rateLimiterConfiguration, circuitBreakerConfiguration, retryConfiguration);
+            cellmConfiguration, rateLimiterConfiguration, circuitBreakerConfiguration, retryConfiguration);
 
         var anthropicConfiguration = configuration.GetRequiredSection(nameof(AnthropicConfiguration)).Get<AnthropicConfiguration>()
             ?? throw new NullReferenceException(nameof(AnthropicConfiguration));
@@ -122,6 +122,7 @@ internal static class ServiceLocator
             anthropicHttpClient.BaseAddress = anthropicConfiguration.BaseAddress;
             anthropicHttpClient.DefaultRequestHeaders.Add("x-api-key", anthropicConfiguration.ApiKey);
             anthropicHttpClient.DefaultRequestHeaders.Add("anthropic-version", anthropicConfiguration.Version);
+            anthropicHttpClient.Timeout = TimeSpan.FromSeconds(cellmConfiguration.HttpTimeoutInSeconds + 1);
         }).AddResilienceHandler($"{nameof(AnthropicRequestHandler)}ResiliencePipeline", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
 
         var googleAiConfiguration = configuration.GetRequiredSection(nameof(GoogleAiConfiguration)).Get<GoogleAiConfiguration>()
@@ -130,6 +131,7 @@ internal static class ServiceLocator
         services.AddHttpClient<IRequestHandler<GoogleAiRequest, GoogleAiResponse>, GoogleAiRequestHandler>(googleHttpClient =>
         {
             googleHttpClient.BaseAddress = googleAiConfiguration.BaseAddress;
+            googleHttpClient.Timeout = TimeSpan.FromSeconds(cellmConfiguration.HttpTimeoutInSeconds + 1);
         }).AddResilienceHandler($"{nameof(GoogleAiRequestHandler)}ResiliencePipeline", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
 
         var openAiConfiguration = configuration.GetRequiredSection(nameof(OpenAiConfiguration)).Get<OpenAiConfiguration>()
@@ -139,6 +141,7 @@ internal static class ServiceLocator
         {
             openAiHttpClient.BaseAddress = openAiConfiguration.BaseAddress;
             openAiHttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {openAiConfiguration.ApiKey}");
+            openAiHttpClient.Timeout = TimeSpan.FromSeconds(cellmConfiguration.HttpTimeoutInSeconds + 1);
         }).AddResilienceHandler($"{nameof(OpenAiRequestHandler)}ResiliencePipeline", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
 
         services

--- a/src/Cellm/appsettings.Local.Anthropic.json
+++ b/src/Cellm/appsettings.Local.Anthropic.json
@@ -4,6 +4,7 @@
         "ApiKey": "YOUR_ANTHROPIC_APIKEY"
     },
     "CellmConfiguration": {
-        "DefaultProvider": "Anthropic"
+        "DefaultProvider": "Anthropic",
+        "HttpTimeoutInSeconds": 30
     }
 }

--- a/src/Cellm/appsettings.Local.GoogleAi.json
+++ b/src/Cellm/appsettings.Local.GoogleAi.json
@@ -3,6 +3,7 @@
         "ApiKey": "YOUR_GOOGLEAI_APIKEY"
     },
     "CellmConfiguration": {
-        "DefaultProvider": "GoogleAI"
+        "DefaultProvider": "GoogleAI",
+        "HttpTimeoutInSeconds": 30
     }
 }

--- a/src/Cellm/appsettings.Local.Mistral.json
+++ b/src/Cellm/appsettings.Local.Mistral.json
@@ -5,6 +5,7 @@
         "ApiKey": "YOUR_MISTRAL_APIKEY"
     },
     "CellmConfiguration": {
-        "DefaultProvider": "OpenAI"
+        "DefaultProvider": "OpenAI",
+        "HttpTimeoutInSeconds": 30
     }
 }

--- a/src/Cellm/appsettings.Local.OpenAi.json
+++ b/src/Cellm/appsettings.Local.OpenAi.json
@@ -4,6 +4,7 @@
         "ApiKey": "YOUR_OPENAI_APIKEY"
     },
     "CellmConfiguration": {
-        "DefaultProvider": "OpenAI"
+        "DefaultProvider": "OpenAI",
+        "HttpTimeoutInSeconds": 30
     }
 }

--- a/src/Cellm/appsettings.json
+++ b/src/Cellm/appsettings.json
@@ -16,7 +16,8 @@
         "DefaultProvider": "OpenAI",
         "DefaultTemperature": 0,
         "MaxOutputTokens": 256,
-        "CacheTimeoutInSeconds": 300
+        "HttpTimeoutInSeconds": 600,
+        "CacheTimeoutInSeconds": 3600
     },
     "RateLimiterConfiguration": {
         "TokenLimit": 4,
@@ -33,8 +34,7 @@
     },
     "RetryConfiguration": {
         "MaxRetryAttempts": 5,
-        "DelayInSeconds": 4,
-        "RequestTimeoutInSeconds": 60
+        "DelayInSeconds": 4
     },
     "SentryConfiguration": {
         "IsEnabled": false,

--- a/src/Cellm/appsettings.json
+++ b/src/Cellm/appsettings.json
@@ -33,7 +33,7 @@
         "BreakDurationInSeconds": 4
     },
     "RetryConfiguration": {
-        "MaxRetryAttempts": 5,
+        "MaxRetryAttempts": 4,
         "DelayInSeconds": 4
     },
     "SentryConfiguration": {


### PR DESCRIPTION
- Assume local model by default, so significantly increase default timeout. It's really sad to run a large model locally and have the response cut short by a timeout.
- Set shorter timeout for hosted model configurations.
- Set HttpClients' timeouts to one hour so it doesn't interfere with polly