### PR TITLE
build: Add global.json to specify .NET SDK version 9.X.X

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Add `global.json` to automatically use .Net v9.X.X, which according to the [README](https://github.com/getcellm/cellm/blob/main/README.md?plain=1#L41) is a requirement.