### PR TITLE
refactor: Add IChatClient with transient lifetime for all providers

### DIFF
--- a/src/Cellm.Models/Behaviors/ToolBehavior.cs
+++ b/src/Cellm.Models/Behaviors/ToolBehavior.cs
@@ -12,7 +12,9 @@ internal class ToolBehavior<TRequest, TResponse>(IOptionsMonitor<ProviderConfigu
     {
         if (providerConfiguration.CurrentValue.EnableTools.Any(t => t.Value))
         {
-            request.Prompt.Options.Tools = functions.Where(f => providerConfiguration.CurrentValue.EnableTools[f.Metadata.Name]).ToList<AITool>();
+            request.Prompt.Options.Tools = functions
+                .Where(f => providerConfiguration.CurrentValue.EnableTools[f.Metadata.Name])
+                .ToList<AITool>();
         }
 
         return await next();

--- a/src/Cellm.Models/Client.cs
+++ b/src/Cellm.Models/Client.cs
@@ -2,24 +2,15 @@
 using Cellm.Models.Prompts;
 using Cellm.Models.Providers;
 using Cellm.Models.Providers.Anthropic;
-using Cellm.Models.Providers.DeepSeek;
-using Cellm.Models.Providers.Llamafile;
-using Cellm.Models.Providers.Mistral;
 using Cellm.Models.Providers.Ollama;
 using Cellm.Models.Providers.OpenAi;
 using Cellm.Models.Providers.OpenAiCompatible;
 using MediatR;
-using Microsoft.Extensions.Options;
 using Polly.Timeout;
 
 namespace Cellm.Models;
 
-internal class Client(
-    ISender sender,
-    IOptionsMonitor<DeepSeekConfiguration> deepSeekConfiguration,
-    IOptionsMonitor<LlamafileConfiguration> llamafileConfiguration,
-    IOptionsMonitor<MistralConfiguration> mistralConfiguration,
-    IOptionsMonitor<OpenAiCompatibleConfiguration> openAiCompatibleConfiguration)
+internal class Client(ISender sender)
 {
     public async Task<Prompt> Send(Prompt prompt, Provider provider, CancellationToken cancellationToken)
     {
@@ -28,12 +19,12 @@ internal class Client(
             IModelResponse response = provider switch
             {
                 Provider.Anthropic => await sender.Send(new AnthropicRequest(prompt), cancellationToken),
-                Provider.DeepSeek => await sender.Send(new OpenAiCompatibleRequest(prompt, deepSeekConfiguration.CurrentValue.BaseAddress, deepSeekConfiguration.CurrentValue.ApiKey), cancellationToken),
-                Provider.Llamafile => await sender.Send(new OpenAiCompatibleRequest(prompt, llamafileConfiguration.CurrentValue.BaseAddress, llamafileConfiguration.CurrentValue.ApiKey), cancellationToken),
-                Provider.Mistral => await sender.Send(new OpenAiCompatibleRequest(prompt, mistralConfiguration.CurrentValue.BaseAddress, mistralConfiguration.CurrentValue.ApiKey), cancellationToken),
+                Provider.DeepSeek => await sender.Send(new OpenAiCompatibleRequest(prompt, Provider.DeepSeek), cancellationToken),
+                Provider.Llamafile => await sender.Send(new OpenAiCompatibleRequest(prompt, Provider.Llamafile), cancellationToken),
+                Provider.Mistral => await sender.Send(new OpenAiCompatibleRequest(prompt, Provider.Mistral), cancellationToken),
                 Provider.Ollama => await sender.Send(new OllamaRequest(prompt), cancellationToken),
                 Provider.OpenAi => await sender.Send(new OpenAiRequest(prompt), cancellationToken),
-                Provider.OpenAiCompatible => await sender.Send(new OpenAiCompatibleRequest(prompt, openAiCompatibleConfiguration.CurrentValue.BaseAddress, openAiCompatibleConfiguration.CurrentValue.ApiKey), cancellationToken),
+                Provider.OpenAiCompatible => await sender.Send(new OpenAiCompatibleRequest(prompt, Provider.OpenAiCompatible), cancellationToken),
                 _ => throw new NotSupportedException($"Provider {provider} is not supported")
             };
 
@@ -45,7 +36,7 @@ internal class Client(
         }
         catch (NullReferenceException ex)
         {
-            throw new CellmModelException($"Null reference error: {ex.Message}", ex);
+            throw new CellmModelException($"Null reference exception: {ex.Message}", ex);
         }
         catch (TimeoutRejectedException ex)
         {

--- a/src/Cellm.Models/Providers/OpenAi/OpenAiRequestHandler.cs
+++ b/src/Cellm.Models/Providers/OpenAi/OpenAiRequestHandler.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Cellm.Models.Providers.OpenAi;
 
-internal class OpenAiRequestHandler([FromKeyedServices(Provider.OpenAi)] IChatClient chatClient) 
+internal class OpenAiRequestHandler([FromKeyedServices(Provider.OpenAi)] IChatClient chatClient)
     : IModelRequestHandler<OpenAiRequest, OpenAiResponse>
 {
 

--- a/src/Cellm.Models/Providers/OpenAiCompatible/OpenAiCompatibleRequest.cs
+++ b/src/Cellm.Models/Providers/OpenAiCompatible/OpenAiCompatibleRequest.cs
@@ -2,7 +2,4 @@ using Cellm.Models.Prompts;
 
 namespace Cellm.Models.Providers.OpenAiCompatible;
 
-internal record OpenAiCompatibleRequest(
-    Prompt Prompt,
-    Uri BaseAddress,
-    string ApiKey) : IModelRequest<OpenAiCompatibleResponse>;
+internal record OpenAiCompatibleRequest(Prompt Prompt, Provider Provider) : IModelRequest<OpenAiCompatibleResponse>;

--- a/src/Cellm.Models/ServiceCollectionExtensions.cs
+++ b/src/Cellm.Models/ServiceCollectionExtensions.cs
@@ -1,20 +1,20 @@
-﻿using System.ClientModel.Primitives;
-using System.ClientModel;
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
 using Cellm.Models.Providers;
 using Cellm.Models.Providers.Anthropic;
+using Cellm.Models.Providers.DeepSeek;
+using Cellm.Models.Providers.Llamafile;
+using Cellm.Models.Providers.Mistral;
 using Cellm.Models.Providers.Ollama;
+using Cellm.Models.Providers.OpenAi;
 using Cellm.Models.Providers.OpenAiCompatible;
 using Cellm.Models.Resilience;
 using MediatR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenAI;
-using Microsoft.Extensions.DependencyInjection;
-using Cellm.Models.Providers.OpenAi;
-using Cellm.Models.Providers.Mistral;
-using Cellm.Models.Providers.Llamafile;
-using Cellm.Models.Providers.DeepSeek;
 
 namespace Cellm.Models;
 
@@ -87,7 +87,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOllamaChatClient(this IServiceCollection services)
     {
         services
-            .AddTransientKeyedChatClient(Provider.Ollama, serviceProvider => {
+            .AddTransientKeyedChatClient(Provider.Ollama, serviceProvider =>
+            {
                 var ollamaConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<OllamaConfiguration>>();
                 var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
 
@@ -104,7 +105,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddDeepSeekChatClient(this IServiceCollection services)
     {
         services
-            .AddTransientKeyedChatClient(Provider.DeepSeek, serviceProvider => {
+            .AddTransientKeyedChatClient(Provider.DeepSeek, serviceProvider =>
+            {
                 var deepSeekConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<DeepSeekConfiguration>>();
                 var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
 
@@ -126,7 +128,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddLlamafileChatClient(this IServiceCollection services)
     {
         services
-            .AddTransientKeyedChatClient(Provider.Llamafile, serviceProvider => {
+            .AddTransientKeyedChatClient(Provider.Llamafile, serviceProvider =>
+            {
                 var llamafileConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<LlamafileConfiguration>>();
                 var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
 
@@ -148,7 +151,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMistralChatClient(this IServiceCollection services)
     {
         services
-            .AddTransientKeyedChatClient(Provider.Mistral, serviceProvider => {
+            .AddTransientKeyedChatClient(Provider.Mistral, serviceProvider =>
+            {
                 var mistralConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<MistralConfiguration>>();
                 var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
 
@@ -170,7 +174,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOpenAiChatClient(this IServiceCollection services)
     {
         services
-            .AddTransientKeyedChatClient(Provider.OpenAi, serviceProvider => {
+            .AddTransientKeyedChatClient(Provider.OpenAi, serviceProvider =>
+            {
                 var openAiConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<OpenAiConfiguration>>();
 
                 return new OpenAIClient(new ApiKeyCredential(openAiConfiguration.CurrentValue.ApiKey))
@@ -184,7 +189,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOpenAiCompatibleChatClient(this IServiceCollection services)
     {
         services
-            .AddTransientKeyedChatClient(Provider.OpenAiCompatible, serviceProvider => {
+            .AddTransientKeyedChatClient(Provider.OpenAiCompatible, serviceProvider =>
+            {
                 var openAiCompatibleConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<OpenAiCompatibleConfiguration>>();
                 var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
 

--- a/src/Cellm.Models/ServiceCollectionExtensions.cs
+++ b/src/Cellm.Models/ServiceCollectionExtensions.cs
@@ -1,20 +1,68 @@
-﻿using Cellm.Models.Behaviors;
+﻿using System.ClientModel.Primitives;
+using System.ClientModel;
 using Cellm.Models.Providers;
 using Cellm.Models.Providers.Anthropic;
 using Cellm.Models.Providers.Ollama;
+using Cellm.Models.Providers.OpenAiCompatible;
 using Cellm.Models.Resilience;
-using Cellm.Models.Tools;
 using MediatR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using OpenAI;
 using Microsoft.Extensions.DependencyInjection;
+using Cellm.Models.Providers.OpenAi;
+using Cellm.Models.Providers.Mistral;
+using Cellm.Models.Providers.Llamafile;
+using Cellm.Models.Providers.DeepSeek;
 
 namespace Cellm.Models;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers a factory for creating IChatClient instances with transient lifetime.
+    /// Identical to AddKeyedChatClient from Microsft.Extensions.AI except this method 
+    /// creates a new instance for each dependency injection request.
+    /// 
+    /// IChatClients are usually registered as singletons, but transient lifetimes are necessary 
+    /// here because the user can change base address or api key at runtime and these settings  
+    /// can only be passed via constructors.
+    /// 
+    /// The performance overhead of creating new instances is negligible, however, because
+    /// execution time is completely dominated by model response time. 
+    /// </summary>
+    /// <param name="serviceCollection"></param>
+    /// <param name="serviceKey"></param>
+    /// <param name="innerClientFactory"></param>
+    /// <returns>A ChatClientBuilder that can be further configured.</returns>
+    public static ChatClientBuilder AddTransientKeyedChatClient(this IServiceCollection serviceCollection, object serviceKey, Func<IServiceProvider, IChatClient> innerClientFactory)
+    {
+        var builder = new ChatClientBuilder(innerClientFactory);
+        serviceCollection.AddKeyedTransient(serviceKey, (IServiceProvider services, object? _) => builder.Build(services));
+        return builder;
+    }
+
+    public static IServiceCollection AddResilientHttpClient(this IServiceCollection services, IConfiguration configuration)
+    {
+        var resiliencePipelineConfigurator = new ResiliencePipelineConfigurator(configuration);
+
+        services
+            .AddHttpClient("ResilientHttpClient", resilientHttpClient =>
+            {
+                resilientHttpClient.Timeout = TimeSpan.FromSeconds(configuration
+                    .GetSection(nameof(ProviderConfiguration))
+                    .GetValue<int>(nameof(ProviderConfiguration.HttpTimeoutInSeconds)));
+            })
+            .AddAsKeyed()
+            .AddResilienceHandler("ResilientHttpClientHandler", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
+
+        return services;
+    }
+
     public static IServiceCollection AddAnthropicChatClient(this IServiceCollection services, IConfiguration configuration)
     {
+
         var resiliencePipelineConfigurator = new ResiliencePipelineConfigurator(configuration);
 
         var anthropicConfiguration = configuration.GetRequiredSection(nameof(AnthropicConfiguration)).Get<AnthropicConfiguration>()
@@ -36,62 +84,127 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection AddOllamaChatClient(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddOllamaChatClient(this IServiceCollection services)
     {
-        var ollamaConfiguration = configuration.GetRequiredSection(nameof(OllamaConfiguration)).Get<OllamaConfiguration>()
-            ?? throw new NullReferenceException(nameof(OllamaConfiguration));
-
         services
-            .AddKeyedChatClient(Provider.Ollama, serviceProvider => new OllamaChatClient(
-                ollamaConfiguration.BaseAddress,
-                ollamaConfiguration.DefaultModel,
-                serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient")))
+            .AddTransientKeyedChatClient(Provider.Ollama, serviceProvider => {
+                var ollamaConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<OllamaConfiguration>>();
+                var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
+
+                return new OllamaChatClient(
+                    ollamaConfiguration.CurrentValue.BaseAddress,
+                    ollamaConfiguration.CurrentValue.DefaultModel,
+                    resilientHttpClient);
+            })
             .UseFunctionInvocation();
 
         return services;
     }
 
-    public static IServiceCollection AddResilientHttpClient(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddDeepSeekChatClient(this IServiceCollection services)
     {
-        var resiliencePipelineConfigurator = new ResiliencePipelineConfigurator(configuration);
-
         services
-            .AddHttpClient("ResilientHttpClient", resilientHttpClient =>
-            {
-                resilientHttpClient.Timeout = TimeSpan.FromSeconds(configuration
-                    .GetSection(nameof(ProviderConfiguration))
-                    .GetValue<int>(nameof(ProviderConfiguration.HttpTimeoutInSeconds)));
+            .AddTransientKeyedChatClient(Provider.DeepSeek, serviceProvider => {
+                var deepSeekConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<DeepSeekConfiguration>>();
+                var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
+
+                var openAiClient = new OpenAIClient(
+                    new ApiKeyCredential(deepSeekConfiguration.CurrentValue.ApiKey),
+                    new OpenAIClientOptions
+                    {
+                        Transport = new HttpClientPipelineTransport(resilientHttpClient),
+                        Endpoint = deepSeekConfiguration.CurrentValue.BaseAddress
+                    });
+
+                return openAiClient.AsChatClient(deepSeekConfiguration.CurrentValue.DefaultModel);
             })
-            .AddAsKeyed()
-            .AddResilienceHandler("ResilientHttpClientHandler", resiliencePipelineConfigurator.ConfigureResiliencePipeline);
+            .UseFunctionInvocation();
 
         return services;
     }
 
-    public static IServiceCollection AddSentryBehavior(this IServiceCollection services)
+    public static IServiceCollection AddLlamafileChatClient(this IServiceCollection services)
     {
         services
-            .AddSingleton(typeof(IPipelineBehavior<,>), typeof(SentryBehavior<,>));
+            .AddTransientKeyedChatClient(Provider.Llamafile, serviceProvider => {
+                var llamafileConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<LlamafileConfiguration>>();
+                var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
+
+                var openAiClient = new OpenAIClient(
+                    new ApiKeyCredential(llamafileConfiguration.CurrentValue.ApiKey),
+                    new OpenAIClientOptions
+                    {
+                        Transport = new HttpClientPipelineTransport(resilientHttpClient),
+                        Endpoint = llamafileConfiguration.CurrentValue.BaseAddress
+                    });
+
+                return openAiClient.AsChatClient(llamafileConfiguration.CurrentValue.DefaultModel);
+            })
+            .UseFunctionInvocation();
 
         return services;
     }
 
-    public static IServiceCollection AddCachingBehavior(this IServiceCollection services)
+    public static IServiceCollection AddMistralChatClient(this IServiceCollection services)
     {
-#pragma warning disable EXTEXP0018 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         services
-            .AddHybridCache();
-#pragma warning restore EXTEXP0018 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            .AddTransientKeyedChatClient(Provider.Mistral, serviceProvider => {
+                var mistralConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<MistralConfiguration>>();
+                var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
 
+                var openAiClient = new OpenAIClient(
+                    new ApiKeyCredential(mistralConfiguration.CurrentValue.ApiKey),
+                    new OpenAIClientOptions
+                    {
+                        Transport = new HttpClientPipelineTransport(resilientHttpClient),
+                        Endpoint = mistralConfiguration.CurrentValue.BaseAddress
+                    });
+
+                return openAiClient.AsChatClient(mistralConfiguration.CurrentValue.DefaultModel);
+            })
+            .UseFunctionInvocation();
+
+        return services;
+    }
+
+    public static IServiceCollection AddOpenAiChatClient(this IServiceCollection services)
+    {
         services
-            .AddSingleton(typeof(IPipelineBehavior<,>), typeof(CacheBehavior<,>));
+            .AddTransientKeyedChatClient(Provider.OpenAi, serviceProvider => {
+                var openAiConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<OpenAiConfiguration>>();
+
+                return new OpenAIClient(new ApiKeyCredential(openAiConfiguration.CurrentValue.ApiKey))
+                    .AsChatClient(openAiConfiguration.CurrentValue.DefaultModel);
+            })
+            .UseFunctionInvocation();
+
+        return services;
+    }
+
+    public static IServiceCollection AddOpenAiCompatibleChatClient(this IServiceCollection services)
+    {
+        services
+            .AddTransientKeyedChatClient(Provider.OpenAiCompatible, serviceProvider => {
+                var openAiCompatibleConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<OpenAiCompatibleConfiguration>>();
+                var resilientHttpClient = serviceProvider.GetKeyedService<HttpClient>("ResilientHttpClient") ?? throw new NullReferenceException("ResilientHttpClient");
+
+                var openAiClient = new OpenAIClient(
+                    new ApiKeyCredential(openAiCompatibleConfiguration.CurrentValue.ApiKey),
+                    new OpenAIClientOptions
+                    {
+                        Transport = new HttpClientPipelineTransport(resilientHttpClient),
+                        Endpoint = openAiCompatibleConfiguration.CurrentValue.BaseAddress
+                    });
+
+                return openAiClient.AsChatClient(openAiCompatibleConfiguration.CurrentValue.DefaultModel);
+            })
+            .UseFunctionInvocation();
 
         return services;
     }
 
     public static IServiceCollection AddTools(this IServiceCollection services, params Delegate[] tools)
     {
-        services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ToolBehavior<,>));
 
         foreach (var tool in tools)
         {

--- a/src/Cellm/AddIn/ExcelFunctions.cs
+++ b/src/Cellm/AddIn/ExcelFunctions.cs
@@ -7,6 +7,7 @@ using Cellm.Models.Providers;
 using Cellm.Services;
 using ExcelDna.Integration;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cellm.AddIn;
 
@@ -33,7 +34,7 @@ public static class ExcelFunctions
     [ExcelArgument(Name = "InstructionsOrTemperature", Description = "A cell or range of cells with instructions or a temperature")] object instructionsOrTemperature,
     [ExcelArgument(Name = "Temperature", Description = "Temperature")] object temperature)
     {
-        var configuration = ServiceLocator.Get<IConfiguration>();
+        var configuration = ServiceLocator.ServiceProvider.GetRequiredService<IConfiguration>();
 
         var provider = configuration.GetSection(nameof(ProviderConfiguration)).GetValue<string>(nameof(ProviderConfiguration.DefaultProvider))
             ?? throw new ArgumentException(nameof(ProviderConfiguration.DefaultProvider));
@@ -73,7 +74,7 @@ public static class ExcelFunctions
     {
         try
         {
-            var arguments = ServiceLocator.Get<ArgumentParser>()
+            var arguments = ServiceLocator.ServiceProvider.GetRequiredService<ArgumentParser>()
                 .AddProvider(providerAndModel)
                 .AddModel(providerAndModel)
                 .AddInstructionsOrContext(instructionsOrContext)
@@ -117,7 +118,7 @@ public static class ExcelFunctions
 
     internal static async Task<string> CompleteAsync(Prompt prompt, Provider provider)
     {
-        var client = ServiceLocator.Get<Client>();
+        var client = ServiceLocator.ServiceProvider.GetRequiredService<Client>();
         var response = await client.Send(prompt, provider, CancellationToken.None);
         return response.Messages.Last().Text ?? throw new NullReferenceException("No text response");
     }

--- a/src/Cellm/AddIn/ExcelRibbon.cs
+++ b/src/Cellm/AddIn/ExcelRibbon.cs
@@ -15,6 +15,7 @@ using Cellm.Models.Providers.OpenAiCompatible;
 using Cellm.Services;
 using ExcelDna.Integration.CustomUI;
 using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Cellm.AddIn.RibbonController;
@@ -107,13 +108,13 @@ public class ExcelRibbon : ExcelDna.Integration.CustomUI.ExcelRibbon
     {
         var providerAndModels = new List<string>();
 
-        var anthropicConfiguration = ServiceLocator.Get<IOptionsMonitor<AnthropicConfiguration>>().CurrentValue;
-        var deepSeekConfiguration = ServiceLocator.Get<IOptionsMonitor<DeepSeekConfiguration>>().CurrentValue;
-        var llamafileConfiguration = ServiceLocator.Get<IOptionsMonitor<LlamafileConfiguration>>().CurrentValue;
-        var mistralConfiguration = ServiceLocator.Get<IOptionsMonitor<MistralConfiguration>>().CurrentValue;
-        var ollamaConfiguration = ServiceLocator.Get<IOptionsMonitor<OllamaConfiguration>>().CurrentValue;
-        var openAiConfiguration = ServiceLocator.Get<IOptionsMonitor<OpenAiConfiguration>>().CurrentValue;
-        var openAiCompatibleConfiguration = ServiceLocator.Get<IOptionsMonitor<OpenAiCompatibleConfiguration>>().CurrentValue;
+        var anthropicConfiguration = ServiceLocator.ServiceProvider.GetRequiredService<IOptionsMonitor<AnthropicConfiguration>>().CurrentValue;
+        var deepSeekConfiguration = ServiceLocator.ServiceProvider.GetRequiredService<IOptionsMonitor<DeepSeekConfiguration>>().CurrentValue;
+        var llamafileConfiguration = ServiceLocator.ServiceProvider.GetRequiredService<IOptionsMonitor<LlamafileConfiguration>>().CurrentValue;
+        var mistralConfiguration = ServiceLocator.ServiceProvider.GetRequiredService<IOptionsMonitor<MistralConfiguration>>().CurrentValue;
+        var ollamaConfiguration = ServiceLocator.ServiceProvider.GetRequiredService<IOptionsMonitor<OllamaConfiguration>>().CurrentValue;
+        var openAiConfiguration = ServiceLocator.ServiceProvider.GetRequiredService<IOptionsMonitor<OpenAiConfiguration>>().CurrentValue;
+        var openAiCompatibleConfiguration = ServiceLocator.ServiceProvider.GetRequiredService<IOptionsMonitor<OpenAiCompatibleConfiguration>>().CurrentValue;
 
         providerAndModels.AddRange(anthropicConfiguration.Models.Select(m => $"{nameof(Provider.Anthropic)}/{m}"));
         providerAndModels.AddRange(deepSeekConfiguration.Models.Select(m => $"{nameof(Provider.DeepSeek)}/{m}"));
@@ -215,7 +216,7 @@ public class ExcelRibbon : ExcelDna.Integration.CustomUI.ExcelRibbon
     {
         if (!enabled)
         {
-            var cache = ServiceLocator.Get<HybridCache>();
+            var cache = ServiceLocator.ServiceProvider.GetRequiredService<HybridCache>();
             await cache.RemoveByTagAsync(nameof(IModelResponse));
 
         }

--- a/src/Cellm/Tools/Functions.cs
+++ b/src/Cellm/Tools/Functions.cs
@@ -6,8 +6,8 @@ using MediatR;
 namespace Cellm.Tools;
 
 /// <summary>
-/// Provides an adapter between MediatR request handlers and Microsoft.Extensions.AI.
-/// This class wraps tools in function definitions suitable for the AIFunctionFactory.
+/// Provides an adapter between MediatR and Microsoft.Extensions.AI by wrapping 
+/// request handlers in function definitions suitable for the AIFunctionFactory.
 /// </summary>
 internal class Functions(ISender sender)
 {


### PR DESCRIPTION
IChatClients are usually registered as singletons, but transient lifetimes are necessary for us because the user can change base address or api key at runtime and these settings can only be passed via constructors.

The performance overhead of creating new instances is negligible, however, because execution time is completely dominated by model response time. 

The PR adds a bit of redundant service configuration code but makes provider configuration via UI more robust (by always reading base address, api key, and model name from provider configuration), easier to reason about, and easier to maintain. 