### PR TITLE
feat: Add max output tokens to PromptBuilder

### DIFF
--- a/src/Cellm.Models/Prompts/PromptBuilder.cs
+++ b/src/Cellm.Models/Prompts/PromptBuilder.cs
@@ -4,8 +4,8 @@ namespace Cellm.Models.Prompts;
 
 public class PromptBuilder
 {
-    private List<ChatMessage> _messages = new();
-    private ChatOptions _options = new();
+    private readonly List<ChatMessage> _messages = [];
+    private readonly ChatOptions _options = new();
 
     public PromptBuilder()
     {
@@ -27,6 +27,12 @@ public class PromptBuilder
     public PromptBuilder SetTemperature(double temperature)
     {
         _options.Temperature = (float)temperature;
+        return this;
+    }
+
+    public PromptBuilder SetMaxOutputTokens(int maxOutputTokens)
+    {
+        _options.MaxOutputTokens = maxOutputTokens;
         return this;
     }
 

--- a/src/Cellm.Models/Providers/Anthropic/AnthropicRequestHandler.cs
+++ b/src/Cellm.Models/Providers/Anthropic/AnthropicRequestHandler.cs
@@ -1,20 +1,15 @@
 ﻿using Cellm.Models.Prompts;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace Cellm.Models.Providers.Anthropic;
 
 internal class AnthropicRequestHandler(
-    [FromKeyedServices(Provider.Anthropic)] IChatClient chatClient,
-    IOptionsMonitor<ProviderConfiguration> providerConfiguration)
+    [FromKeyedServices(Provider.Anthropic)] IChatClient chatClient)
     : IModelRequestHandler<AnthropicRequest, AnthropicResponse>
 {
     public async Task<AnthropicResponse> Handle(AnthropicRequest request, CancellationToken cancellationToken)
     {
-        // Required by Anthropic API
-        request.Prompt.Options.MaxOutputTokens ??= providerConfiguration.CurrentValue.MaxOutputTokens;
-
         var chatResponse = await chatClient.GetResponseAsync(
             request.Prompt.Messages,
             request.Prompt.Options,

--- a/src/Cellm/AddIn/ArgumentParser.cs
+++ b/src/Cellm/AddIn/ArgumentParser.cs
@@ -6,8 +6,6 @@ using Microsoft.Extensions.Configuration;
 
 namespace Cellm.AddIn;
 
-public record Arguments(Provider Provider, string Model, string Context, string Instructions, double Temperature);
-
 public class ArgumentParser
 {
     private string? _provider;
@@ -231,7 +229,7 @@ public class ArgumentParser
             .ToString();
     }
 
-    private double ParseTemperature(double temperature)
+    private static double ParseTemperature(double temperature)
     {
         if (temperature < 0 || temperature > 1)
         {

--- a/src/Cellm/AddIn/Arguments.cs
+++ b/src/Cellm/AddIn/Arguments.cs
@@ -1,0 +1,5 @@
+﻿using Cellm.Models.Providers;
+
+namespace Cellm.AddIn;
+
+public record Arguments(Provider Provider, string Model, string Context, string Instructions, double Temperature);

--- a/src/Cellm/AddIn/ExcelAddin.cs
+++ b/src/Cellm/AddIn/ExcelAddin.cs
@@ -9,9 +9,9 @@ public class ExcelAddIn : IExcelAddIn
     {
         ExcelIntegration.RegisterUnhandledExceptionHandler(obj =>
         {
-            var ex = (Exception)obj;
-            SentrySdk.CaptureException(ex);
-            return ex.Message;
+            var e = (Exception)obj;
+            SentrySdk.CaptureException(e);
+            return e.Message;
         });
 
         _ = ServiceLocator.ServiceProvider;

--- a/src/Cellm/Cellm.csproj
+++ b/src/Cellm/Cellm.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
+    <PackageReference Include="Mistral.SDK" Version="2.1.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.7" />
     <PackageReference Include="PdfPig" Version="0.1.10" />
     <PackageReference Include="Sentry.Extensions.Logging" Version="5.5.1" />

--- a/src/Cellm/packages.lock.json
+++ b/src/Cellm/packages.lock.json
@@ -223,6 +223,16 @@
           "Microsoft.Extensions.Primitives": "9.0.4"
         }
       },
+      "Mistral.SDK": {
+        "type": "Direct",
+        "requested": "[2.1.1, )",
+        "resolved": "2.1.1",
+        "contentHash": "dBTLqmtfj7C62meCEB9l7VKDtRDDFQgYbx8a5+8uTLtU9bUmw9xYMmyTixHcfOGAQ8LlrXOWNOS6dEFMEgFHhQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Extensions.AI.Abstractions": "9.3.0-preview.1.25161.3"
+        }
+      },
       "ModelContextProtocol": {
         "type": "Direct",
         "requested": "[0.1.0-preview.7, )",


### PR DESCRIPTION
Apparently, Mistral expects max output tokens in a way different than what the official OpenAI client sends, so add Mistral IChatClient dependency. It's the same guy that made the Anthropic IChatClient, so this is fine.