### PR TITLE
fix: Empty cells exception

### DIFF
--- a/src/Cellm/Models/Prompts/StructuredOutput.cs
+++ b/src/Cellm/Models/Prompts/StructuredOutput.cs
@@ -46,7 +46,7 @@ public static class StructuredOutput
         }
         catch (JsonException ex)
         {
-            // Do nothing, response will be returned ina  single cell
+            // Do nothing, response will be returned in a single cell
             var loggerFactory = CellmAddIn.Services.GetRequiredService<ILoggerFactory>()
                 .CreateLogger(nameof(StructuredOutput));
 

--- a/src/Cellm/Models/Prompts/StructuredOutput.cs
+++ b/src/Cellm/Models/Prompts/StructuredOutput.cs
@@ -39,10 +39,7 @@ public static class StructuredOutput
                 _ => null
             };
 
-            if (structuredOutput is not null)
-            {
-                return true;
-            }
+            return structuredOutput is not null;
         }
         catch (JsonException ex)
         {
@@ -51,9 +48,9 @@ public static class StructuredOutput
                 .CreateLogger(nameof(StructuredOutput));
 
             loggerFactory.LogWarning("{message}", ex.Message);
-        }
 
-        return false;
+            return false;
+        }
     }
 
     private record Array2d(string[][] Data);


### PR DESCRIPTION
This PR let's the model know if cells are empty. Previously, we would throw an exception so the user could see that cells are empty, under the assumption that the user will never provide empty cells on purpose. That was perhaps naive. #218 shows a real-life example where it is better to just let the model know that all cells were empty, so it can make appropriate response