### PR TITLE
Add Requesty as a provider

### DIFF
--- a/src/Cellm.Tests/Integration/Helpers/ProviderTestFixture.cs
+++ b/src/Cellm.Tests/Integration/Helpers/ProviderTestFixture.cs
@@ -13,6 +13,7 @@ using Cellm.Models.Providers.Ollama;
 using Cellm.Models.Providers.OpenAi;
 using Cellm.Models.Providers.OpenAiCompatible;
 using Cellm.Models.Providers.OpenRouter;
+using Cellm.Models.Providers.Requesty;
 using Cellm.Tools.ModelContextProtocol;
 using MediatR;
 using Microsoft.Extensions.Configuration;
@@ -85,6 +86,7 @@ public class ProviderTestFixture : IDisposable
             Provider.OpenAi => HasApiKey<OpenAiConfiguration>(),
             Provider.OpenAiCompatible => HasApiKey<OpenAiCompatibleConfiguration>(),
             Provider.OpenRouter => HasApiKey<OpenRouterConfiguration>(),
+            Provider.Requesty => HasApiKey<RequestyConfiguration>(),
             _ => false
         };
     }
@@ -101,6 +103,7 @@ public class ProviderTestFixture : IDisposable
             Provider.OpenAi => GetConfig<OpenAiConfiguration>().DefaultModel,
             Provider.OpenAiCompatible => GetConfig<OpenAiCompatibleConfiguration>().DefaultModel,
             Provider.OpenRouter => GetConfig<OpenRouterConfiguration>().DefaultModel,
+            Provider.Requesty => GetConfig<RequestyConfiguration>().DefaultModel,
             _ => throw new ArgumentException($"Unknown provider: {provider}")
         };
     }

--- a/src/Cellm.Tests/Unit/PipelineTests.cs
+++ b/src/Cellm.Tests/Unit/PipelineTests.cs
@@ -29,6 +29,7 @@ public class PipelineTests : IClassFixture<PipelineTestFixture>
         [Provider.DeepSeek, "deepseek-chat"],
         [Provider.Ollama, "llama3.2"],
         [Provider.OpenRouter, "openai/gpt-4.1-mini"],
+        [Provider.Requesty, "openai/gpt-4o-mini"],
     ];
 
     [Theory]

--- a/src/Cellm/AddIn/CellmAddIn.cs
+++ b/src/Cellm/AddIn/CellmAddIn.cs
@@ -16,6 +16,7 @@ using Cellm.Models.Providers.Ollama;
 using Cellm.Models.Providers.OpenAi;
 using Cellm.Models.Providers.OpenAiCompatible;
 using Cellm.Models.Providers.OpenRouter;
+using Cellm.Models.Providers.Requesty;
 using Cellm.Models.Resilience;
 using Cellm.Tools;
 using Cellm.Tools.FileReader;
@@ -101,6 +102,7 @@ public class CellmAddIn : IExcelAddIn
             .Configure<OpenAiConfiguration>(configuration.GetRequiredSection(nameof(OpenAiConfiguration)))
             .Configure<OpenAiCompatibleConfiguration>(configuration.GetRequiredSection(nameof(OpenAiCompatibleConfiguration)))
             .Configure<OpenRouterConfiguration>(configuration.GetRequiredSection(nameof(OpenRouterConfiguration)))
+            .Configure<RequestyConfiguration>(configuration.GetRequiredSection(nameof(RequestyConfiguration)))
             .Configure<ResilienceConfiguration>(configuration.GetRequiredSection(nameof(ResilienceConfiguration)))
             .Configure<SentryConfiguration>(configuration.GetRequiredSection(nameof(SentryConfiguration)));
 
@@ -185,7 +187,8 @@ public class CellmAddIn : IExcelAddIn
             .AddResilientHttpClient(resilienceConfiguration, cellmAddInConfiguration, Provider.Mistral)
             .AddResilientHttpClient(resilienceConfiguration, cellmAddInConfiguration, Provider.Ollama)
             .AddResilientHttpClient(resilienceConfiguration, cellmAddInConfiguration, Provider.OpenAiCompatible)
-            .AddResilientHttpClient(resilienceConfiguration, cellmAddInConfiguration, Provider.OpenRouter);
+            .AddResilientHttpClient(resilienceConfiguration, cellmAddInConfiguration, Provider.OpenRouter)
+            .AddResilientHttpClient(resilienceConfiguration, cellmAddInConfiguration, Provider.Requesty);
 
 #pragma warning disable EXTEXP0018 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         services
@@ -205,7 +208,8 @@ public class CellmAddIn : IExcelAddIn
             .AddOllamaChatClient()
             .AddOpenAiChatClient()
             .AddOpenAiCompatibleChatClient()
-            .AddOpenRouterChatClient();
+            .AddOpenRouterChatClient()
+            .AddRequestyChatClient();
 
         // Add tools
         services
@@ -253,7 +257,8 @@ public class CellmAddIn : IExcelAddIn
             Services.GetRequiredService<IOptionsMonitor<OllamaConfiguration>>().CurrentValue,
             Services.GetRequiredService<IOptionsMonitor<OpenAiConfiguration>>().CurrentValue,
             Services.GetRequiredService<IOptionsMonitor<OpenAiCompatibleConfiguration>>().CurrentValue,
-            Services.GetRequiredService<IOptionsMonitor<OpenRouterConfiguration>>().CurrentValue
+            Services.GetRequiredService<IOptionsMonitor<OpenRouterConfiguration>>().CurrentValue,
+            Services.GetRequiredService<IOptionsMonitor<RequestyConfiguration>>().CurrentValue
         ];
     }
 

--- a/src/Cellm/AddIn/UserInterface/Resources/Requesty.svg
+++ b/src/Cellm/AddIn/UserInterface/Resources/Requesty.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="#111111" viewBox="0 0 24 24" focusable="false"><path d="M4 4h16a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1zm1 2v12h14V6H5zm3 3h8v2H8V9zm0 4h5v2H8v-2z"/></svg>

--- a/src/Cellm/AddIn/UserInterface/Ribbon/RibbonModelGroup.cs
+++ b/src/Cellm/AddIn/UserInterface/Ribbon/RibbonModelGroup.cs
@@ -13,6 +13,7 @@ using Cellm.Models.Providers.Ollama;
 using Cellm.Models.Providers.OpenAi;
 using Cellm.Models.Providers.OpenAiCompatible;
 using Cellm.Models.Providers.OpenRouter;
+using Cellm.Models.Providers.Requesty;
 using Cellm.Users;
 using ExcelDna.Integration.CustomUI;
 using Microsoft.Extensions.AI;
@@ -539,6 +540,9 @@ public partial class RibbonMain
                     break;
                 case Provider.OpenRouter:
                     currentBaseAddress = GetProviderConfiguration<OpenRouterConfiguration>()?.BaseAddress?.ToString() ?? "";
+                    break;
+                case Provider.Requesty:
+                    currentBaseAddress = GetProviderConfiguration<RequestyConfiguration>()?.BaseAddress?.ToString() ?? "";
                     break;
                 default:
                     break;

--- a/src/Cellm/Cellm.csproj
+++ b/src/Cellm/Cellm.csproj
@@ -29,6 +29,7 @@
     <None Remove="AddIn\UserInterface\Resources\ollama.png" />
     <None Remove="AddIn\UserInterface\Resources\openai.png" />
     <None Remove="AddIn\UserInterface\Resources\OpenRouter.svg" />
+    <None Remove="AddIn\UserInterface\Resources\Requesty.svg" />
     <None Remove="appsettings.json" />
   </ItemGroup>
 
@@ -94,5 +95,6 @@
     <EmbeddedResource Include="AddIn\UserInterface\Resources\Ollama.png" />
     <EmbeddedResource Include="AddIn\UserInterface\Resources\OpenAi.png" />
     <EmbeddedResource Include="AddIn\UserInterface\Resources\OpenRouter.svg" />
+    <EmbeddedResource Include="AddIn\UserInterface\Resources\Requesty.svg" />
   </ItemGroup>
 </Project>

--- a/src/Cellm/Models/Providers/Provider.cs
+++ b/src/Cellm/Models/Providers/Provider.cs
@@ -12,5 +12,6 @@ public enum Provider
     Ollama,
     OpenAi,
     OpenAiCompatible,
-    OpenRouter
+    OpenRouter,
+    Requesty
 }

--- a/src/Cellm/Models/Providers/Requesty/RequestyConfiguration.cs
+++ b/src/Cellm/Models/Providers/Requesty/RequestyConfiguration.cs
@@ -1,0 +1,35 @@
+using Cellm.Users;
+using Microsoft.Extensions.AI;
+
+namespace Cellm.Models.Providers.Requesty;
+
+internal class RequestyConfiguration : IProviderConfiguration
+{
+    public Provider Id { get => Provider.Requesty; }
+
+    public string Name { get => "Requesty"; }
+
+    public Entitlement Entitlement { get => Entitlement.EnableRequestyProvider; }
+
+    public string Icon { get => $"AddIn/UserInterface/Resources/{nameof(Provider.Requesty)}.svg"; }
+
+    public Uri BaseAddress => new("https://router.requesty.ai/v1");
+
+    public string DefaultModel { get; init; } = "openai/gpt-4o-mini";
+
+    public string ApiKey { get; init; } = string.Empty;
+
+    public string SmallModel { get; init; } = string.Empty;
+
+    public string MediumModel { get; init; } = string.Empty;
+
+    public string LargeModel { get; init; } = string.Empty;
+
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; init; } = [];
+
+    public bool SupportsJsonSchemaResponses { get; init; } = true;
+
+    public bool SupportsStructuredOutputWithTools { get; init; } = true;
+
+    public bool IsEnabled { get; init; } = false;
+}

--- a/src/Cellm/Models/ServiceCollectionExtensions.cs
+++ b/src/Cellm/Models/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Cellm.Models.Providers.Ollama;
 using Cellm.Models.Providers.OpenAi;
 using Cellm.Models.Providers.OpenAiCompatible;
 using Cellm.Models.Providers.OpenRouter;
+using Cellm.Models.Providers.Requesty;
 using Cellm.Models.Resilience;
 using Cellm.Users;
 using Microsoft.Extensions.AI;
@@ -474,6 +475,37 @@ internal static class ServiceCollectionExtensions
                     });
 
                 return openAiClient.GetChatClient(openRouterConfiguration.CurrentValue.DefaultModel).AsIChatClient();
+            }, ServiceLifetime.Transient)
+            .UseFunctionInvocation();
+
+        return services;
+    }
+
+    public static IServiceCollection AddRequestyChatClient(this IServiceCollection services)
+    {
+        services
+            .AddKeyedChatClient(Provider.Requesty, serviceProvider =>
+            {
+                var account = serviceProvider.GetRequiredService<Account>();
+                account.ThrowIfNotEntitled(Entitlement.EnableRequestyProvider);
+
+                var requestyConfiguration = serviceProvider.GetRequiredService<IOptionsMonitor<RequestyConfiguration>>();
+                var resilientHttpClient = serviceProvider.GetResilientHttpClient(Provider.Requesty);
+
+                if (string.IsNullOrWhiteSpace(requestyConfiguration.CurrentValue.ApiKey))
+                {
+                    throw new CellmException($"Empty {nameof(RequestyConfiguration.ApiKey)} for {Provider.Requesty}. Please set your API key.");
+                }
+
+                var openAiClient = new OpenAIClient(
+                    new ApiKeyCredential(requestyConfiguration.CurrentValue.ApiKey),
+                    new OpenAIClientOptions
+                    {
+                        Transport = new HttpClientPipelineTransport(resilientHttpClient),
+                        Endpoint = requestyConfiguration.CurrentValue.BaseAddress
+                    });
+
+                return openAiClient.GetChatClient(requestyConfiguration.CurrentValue.DefaultModel).AsIChatClient();
             }, ServiceLifetime.Transient)
             .UseFunctionInvocation();
 

--- a/src/Cellm/Users/Entitlement.cs
+++ b/src/Cellm/Users/Entitlement.cs
@@ -15,6 +15,7 @@ public enum Entitlement
     EnableOpenAiCompatibleProviderLocalModels,
     EnableOpenAiCompatibleProviderHostedModels,
     EnableOpenRouterProvider,
+    EnableRequestyProvider,
     EnableModelContextProtocol,
     DisableTelemetry
 }

--- a/src/Cellm/Users/Models/Entitlements.cs
+++ b/src/Cellm/Users/Models/Entitlements.cs
@@ -24,7 +24,8 @@ internal class Entitlements()
         Entitlement.EnableOpenAiCompatibleProvider,
         Entitlement.EnableOpenAiCompatibleProviderHostedModels,
         Entitlement.EnableOpenAiCompatibleProviderLocalModels,
-        Entitlement.EnableOpenRouterProvider
+        Entitlement.EnableOpenRouterProvider,
+        Entitlement.EnableRequestyProvider
     ];
 
     public IEnumerable<Entitlement> AsEnumerable()

--- a/src/Cellm/appsettings.json
+++ b/src/Cellm/appsettings.json
@@ -113,6 +113,15 @@
         "LargeModel": "anthropic/claude-opus-4-6",
         "IsEnabled": true
     },
+    "RequestyConfiguration": {
+        "BaseAddress": "https://router.requesty.ai/v1",
+        "DefaultModel": "openai/gpt-4o-mini",
+        "ApiKey": "",
+        "SmallModel": "openai/gpt-4o-mini",
+        "MediumModel": "openai/gpt-4o",
+        "LargeModel": "anthropic/claude-sonnet-4-5",
+        "IsEnabled": true
+    },
     "ModelContextProtocolConfiguration": {
         "StdioServers": [
             {


### PR DESCRIPTION
Adds Requesty as a provider, mirroring the existing OpenRouter provider end-to-end.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth. It reuses the same OpenAI-compatible chat-client path OpenRouter uses.

Changes:
- `Models/Providers/Provider.cs`: `Requesty` enum member.
- `Models/Providers/Requesty/RequestyConfiguration.cs` (new): `IProviderConfiguration` mirroring `OpenRouterConfiguration` (`BaseAddress = https://router.requesty.ai/v1`, `DefaultModel = openai/gpt-4o-mini`).
- `Models/ServiceCollectionExtensions.cs`: `AddRequestyChatClient()` via the OpenAI-compatible client (mirrors OpenRouter).
- `Users/Entitlement.cs` + `Users/Models/Entitlements.cs`: `EnableRequestyProvider`.
- `AddIn/CellmAddIn.cs`, `AddIn/UserInterface/Ribbon/RibbonModelGroup.cs`: config binding, HTTP client, provider list, ribbon base-address case.
- `appsettings.json`: `RequestyConfiguration` section (verified model ids).
- `Cellm.csproj`: embeds `Requesty.svg`.
- `AddIn/UserInterface/Resources/Requesty.svg` (new): placeholder icon (neutral glyph, not a Requesty logo) — happy to swap for the official mark.
- Tests: added Requesty to the unit pipeline (mock client) and the integration fixture helpers; left the live-key integration Theories untouched (Requesty isn't in CI secrets, matching how OpenRouter is gated).

Note: I couldn't run `dotnet build` locally (net9.0-windows / WinForms target on a non-Windows machine), so this hasn't been compiled here — please give it a build. Every reference was mirrored 1:1 against OpenRouter.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.