### PR TITLE
build: eliminate known build warnings

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Target Name="RemoveUnusedOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)%(Analyzer.Extension)' == 'OllamaSharp.SourceGenerators.dll'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Cellm.Installers/Cellm.Installer.wixproj
+++ b/src/Cellm.Installers/Cellm.Installer.wixproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputName>Cellm-AddIn-$(Configuration)-$(Platform)</OutputName>
     <SignOutput>false</SignOutput>
+    <SuppressIces>ICE91</SuppressIces>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="WixToolset.Netfx.wixext" Version="6.0.2" />


### PR DESCRIPTION
- remove the unused OllamaSharp source generator from compiler analyzer inputs
- suppress WiX ICE91 for the installer, which is explicitly scoped to per-user installation under `AppDataFolder`